### PR TITLE
fix: add setuptools_scm to fix build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @conda-forge/scikit-hep @andrzejnovak @chrisburr
+* @andrzejnovak @chrisburr @conda-forge/scikit-hep

--- a/README.md
+++ b/README.md
@@ -147,4 +147,5 @@ Feedstock Maintainers
 
 * [@andrzejnovak](https://github.com/andrzejnovak/)
 * [@chrisburr](https://github.com/chrisburr/)
+* [@conda-forge/scikit-hep](https://github.com/orgs/conda-forge/teams/scikit-hep/)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
           echo "##vso[task.setvariable variable=log]$git_log"
         displayName: Obtain commit message
       - bash: echo "##vso[task.setvariable variable=RET]false"
-        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
         displayName: Skip build?
       - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
         name: result

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,11 @@ requirements:
 test:
   imports:
     - mplhep_data
+  commands:
+    - pip check
+    - pip show mplhep_data | grep "{{ version }}"
+  requires:
+    - pip
 
 about:
   home: https://github.com/scikit-hep/mplhep_data

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cd1f3ad3af9dbff33aef9e7406d2130d624a0bd1d5aa5970fc713a6421165a4e
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -19,6 +19,7 @@ requirements:
     - python >=3.7
     - pip
     - setuptools
+    - setuptools_scm
   run:
     - python >=3.7
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The recipe misses `setuptools_scm` to retrieve version from VCS. See https://github.com/conda-forge/mplhep_data-feedstock/pull/4#discussion_r1825956861.

cc: @chrisburr (sorry for so many pings 😬)